### PR TITLE
Run the init action callback late

### DIFF
--- a/vip-go-geo-uniques.php
+++ b/vip-go-geo-uniques.php
@@ -13,7 +13,8 @@ class VIP_Go_Geo_Uniques {
 	private static $supported_locations = array();
 
 	function __construct() {
-		add_action( 'init', array( $this, 'init' ), 1 );
+		// We want to give developers enough room for registering their supported locations. Run this late.
+		add_action( 'init', array( $this, 'init' ), 9999, 0 );
 	}
 
 	static function get_country_code() {


### PR DESCRIPTION
Running the `VIP_Go_Geo_Uniques::init` method on `init` action with priority 1 gives developers very little room for registering their supported locations (eg.: from init action on default priority of 10), so the Vary header set action might not get hooked, due to failing `count( self::$supported_locations ) < 1` condition.

The commit hooks the `VIP_Go_Geo_Uniques::init` to `init` action with priority of 9999 which could be enough late for standard use cases, but should still give developers some room for hooking some necessary callbacks even later.

The commit also defines 0 args to be passed to the callback, simply for improved redability.