### PR TITLE
Add static method get_registered_locations()

### DIFF
--- a/vip-go-geo-uniques.php
+++ b/vip-go-geo-uniques.php
@@ -45,6 +45,10 @@ class VIP_Go_Geo_Uniques {
 		return in_array( $loc, self::$supported_locations, true );
 	}
 
+	static function get_registered_locations() {
+		return static::$supported_locations;
+	}
+
 	function init() {
 		if ( is_admin() ) {
 			return;


### PR DESCRIPTION
The WPCOM version has a static function `get_registered_locations()` that returns the `$supported_locations` property.  We should add this for clients who are migrating from WPCOM --> VIP Go and are calling `WPCOM_Geo_Uniques::get_registered_locations()` in their implementation seeing as `$supported_locations` cannot be accessed from outside the class.