### PR TITLE
Don't replace other Vary headers

### DIFF
--- a/vip-go-geo-uniques.php
+++ b/vip-go-geo-uniques.php
@@ -71,7 +71,7 @@ class VIP_Go_Geo_Uniques {
 		}
 
 		add_action( 'send_headers', function() {
-			header('Vary: X-Country-Code');
+			header( 'Vary: X-Country-Code', false );
 		});
 	}
 }


### PR DESCRIPTION
Because that's just not nice. Also, because it breaks things.

For example, if another bit of code did this prior to loading the geo-uniques plugin:

```
add_action( 'send_headers', function() {
	header( 'Vary: Foo', false );
} );
```

We could expect the site to respond with the following headers:

```
Vary: Foo
Vary: X-Country-Code
```

But we end up just sending this:

```
Vary: X-Country-Code
```

This PR fixes that.