### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/vip-go-geo-uniques.php
+++ b/vip-go-geo-uniques.php
@@ -3,6 +3,7 @@
  * Plugin Name: VIP Go Geo Uniques
  * Description: Varnish-friendly way to handle geo-targetting of users at a specific set of locations.
  * Version: 0.1.01
+ * Requires at least: 6.4
  * Author: Automattic, WordPress VIP
  * License: GPLv2
  **/


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.